### PR TITLE
Made day of week a google sheets function, configurable

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -12,6 +12,15 @@ function getConfigDetails(){
     history_size=60;
     cfg.getRange(HISTORY_LOAD_SIZE_CELL).setValue(history_size);
   }
+  
+  var weekday_type = cfg.getRange(WEEKDAY_TYPE_CELL).getValue();
+  if(![1,2,3].includes(weekday_type)){
+    // No weekday type specified. Let's go with 1.
+    weekday_type=1;
+  }  else {
+    weekday_type=WEEKDAY_TYPE_CELL_REFERENCE;
+  }
+
   return {
     "whoop":{
       "timezone" :tz,
@@ -21,6 +30,7 @@ function getConfigDetails(){
       "token_expiry": whoop_token_expiry,
       "username": whoop_username,
       "history_size": history_size,
+      "weekday_type": weekday_type,
       "id": whoop_id,
       "http_options":
       {

--- a/constants.gs
+++ b/constants.gs
@@ -25,3 +25,8 @@ var DATETIME_FORMAT_FULL="yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
 var DATETIME_FORMAT_START="yyyy-MM-dd'T'00:00:00.SSS'Z'";
 // Used to start at 0:00 on a given date
 var DATETIME_FORMAT_END="yyyy-MM-dd'T'23:59:59.999'Z'";
+
+
+var WEEKDAY_TYPE_CELL="B11"
+var WEEKDAY_TYPE_CELL_REFERENCE="INDIRECT(\""+CONFIG_SHEET_NAME+"!"+WEEKDAY_TYPE_CELL+"\")";
+

--- a/whoop.gs
+++ b/whoop.gs
@@ -179,7 +179,9 @@ function dayOfWeek(dateString){
   return dt.getDay()+ " "+weekday;
 }
 
+
 function whoop_get_history(start_date, end_date){
+  var config=getConfigDetails();
   var data=whoop_get_time_series("cycles", start_date, end_date);
   var rows=[];
   rows[0]=["Date","Strain","Recovery","Sleep Score","Sleep Duration","Workouts","HRV","RHR","Average HR","Max HR", "KJ", "Comment", "Respiratory Rate", "HRV (ms)",	"Sleep (hr)",	"Recovery Type", "Day of Week","Calories","Sleep Start","Sleep End"];
@@ -203,7 +205,7 @@ function whoop_get_history(start_date, end_date){
                (row.recovery && row.recovery.heartRateVariabilityRmssd)?row.recovery.heartRateVariabilityRmssd * 1000:null,
                (row.sleep && row.sleep.qualityDuration)? row.sleep.qualityDuration / (1000*60*60) : null,
                (row.recovery && row.recovery.score )? (row.recovery.score>=67 ? "Green": (row.recovery.score>=34? "Yellow" : "Red")) :null,           
-               dayOfWeek(row.days[0]),
+               '=WEEKDAY(INDIRECT("A"&ROW()),'+config.whoop.weekday_type+')& " " &TEXT(INDIRECT("A"&ROW()),"ddd")',
                (row.strain && row.strain.kilojoules)?row.strain.kilojoules/4.184:null,
                (row.sleep && row.sleep.sleeps && row.sleep.sleeps.length>0 && row.sleep.sleeps[0].during)?new Date(row.sleep.sleeps[0].during.lower).getTime():null,
                (row.sleep && row.sleep.sleeps && row.sleep.sleeps.length>0 && row.sleep.sleeps[0].during)?new Date(row.sleep.sleeps[0].during.upper).getTime():null,


### PR DESCRIPTION
#4  - This updates the day of week calculation to be based on Google Sheets WEEKDAY+TEXT function with the option to configure as 0 or 1 based monday start, or a sunday start based on cell at value B11.  Google Sheet (copyable) updated as well, and if no value is found (must be 1,2,3) then 2 is assumed.

See also: https://support.google.com/docs/answer/3092985?hl=en